### PR TITLE
Update sources using absolute references

### DIFF
--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dl.min.io/server/minio/release/linux-amd64/minio
-SOURCE_SUM=d68470a516706a81f7bef664f2fd8637bf316049262aa6da7f085d1425dda815
+SOURCE_URL=https://dl.min.io/client/mc/release/linux-amd64/mc.RELEASE.2022-02-16T05-54-01Z
+SOURCE_SUM=bcb1934a386d646cfcd0e6f2a9f81399dddc877274510e62c3504cf609a0fa9e
 SOURCE_SUM_PRG=sha256sum
 SOURCE_IN_SUBDIR=false
 SOURCE_FILENAME=minio

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://dl.min.io/server/minio/release/linux-arm64/minio
-SOURCE_SUM=a1c895afc59d7487a61beb3ce0ff1cdf13d00a3fdd001a2af35453ba2149733d
+SOURCE_URL=https://dl.min.io/client/mc/release/linux-arm64/mc.RELEASE.2022-02-16T05-54-01Z
+SOURCE_SUM=0dfb0ad720a79bcb3e4340c069a2d8cbec8b09042cb818a1c06bdc23d8234beb
 SOURCE_SUM_PRG=sha256sum
 SOURCE_IN_SUBDIR=false
 SOURCE_FILENAME=minio


### PR DESCRIPTION
To avoid future source corrupt error

## Problem

Got a Corrupt Source warning error during installation

## Solution

Used absolute reference for download links
