### PR TITLE
Fix mc cannot list buckets after upgrade #74

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -106,7 +106,7 @@ ynh_systemctl --service=$app --action="start" --log_path="systemd" #--wait_until
 ynh_script_progression "Configuring$app client..."
 
 pushd $install_dir
-	ynh_hide_warnings ynh_exec_as_app ./mc --no-color alias set minio "https://$domain" "$admin" "$password" --api S3v4
+	ynh_hide_warnings ynh_exec_as_app ./mc --autocompletion --no-color alias set minio "http://127.0.0.1:$port" "$admin" "$password" --api S3v4
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

- After upgrading minio (even to the same version), minio-mc fails to connect to the server. 

Fixes #74 

## Solution

- Rather use internal URL for the alias, so mc does not check the certificate. This commit is just copied from the install script.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
