### PR TITLE
Easier bucket creation and doc

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -3,7 +3,7 @@
 During the install process, MinIO will install both the MinIO server and MinIO client.
 If your app needs to use an Amazon S3 storage, you are invited to use the MinIO client to create and setup buckets as per your app's requirements.
 
-### First step: define MinIO user credentials
+### First step: define MinIO credentials
 
 ```bash
 #=================================================
@@ -22,7 +22,7 @@ ynh_app_setting_set --key=minio_secret_key --value=$minio_secret_key
 
 ### Second step: create and setup your bucket
 
-Below we assume we simply create a bucket and a user with the name of the app.
+Below we assume we simply create a bucket and an access key with the name of the app.
 ```bash
 #=================================================
 # SETUP MINIO BUCKET

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,30 +1,63 @@
 ## How to create a YunoHost app using MinIO
 
 During the install process, MinIO will install both the MinIO server and MinIO client.
-If your app needs to use an Amazon S3 storage, I recommend to use the MinIO client to create and setup buckets as per your app's requirements. You can have a look at outline_ynh app for reference.
+If your app needs to use an Amazon S3 storage, you are invited to use the MinIO client to create and setup buckets as per your app's requirements.
 
-### First step: retrieve MinIO credentials
+### First step: define MinIO user credentials
 
-```
+```bash
 #=================================================
 # SETUP MINIO CREDENTIALS
 #=================================================
 minio_domain=$(ynh_app_setting_get --app="minio" --key=domain)
-minio_admin=$(ynh_app_setting_get --app="minio" --key=admin)
-minio_password=$(ynh_app_setting_get --app="minio" --key=password)
-mc_path=$(ynh_app_setting_get --app="minio" --key=mc_path)
+minio_secret_key=$(ynh_string_random -l 32)
+minio_install_dir=$(ynh_app_setting_get --app="minio" --key=install_dir)
+minio_access_key=$app
+minio_bucket=$app
+
+ynh_app_setting_set --key=minio_access_key --value=$minio_access_key
+ynh_app_setting_set --key=minio_bucket --value=$minio_bucket
+ynh_app_setting_set --key=minio_secret_key --value=$minio_secret_key
 ```
 
 ### Second step: create and setup your bucket
 
-```
+Below we assume we simply create a bucket and a user with the name of the app.
+```bash
 #=================================================
 # SETUP MINIO BUCKET
 #=================================================
-ynh_script_progression --message="Setting up MinIO bucket for YOURAPP..." --weight=1
+ynh_script_progression --message="Setting up MinIO bucket..." --weight=1
 
-pushd "$mc_path"
-	ynh_exec_warn_less sudo -u minio ./mc mb minio/NAME_OF_YOUR_BUCKET --region "NAME_OF_YOUR_REGION"
-	ynh_exec_warn_less sudo -u minio ./mc policy set NEEDED_POLICY minio/NAME_OF_YOUR_BUCKET
-popd
+sudo -u minio "$minio_install_dir/setup_app_bucket.sh" --app="$app" --secret="$minio_secret_key" \
+  --with-versioning --region=YOUR_REGION # --with-versioning and --region are optional
 ```
+
+Where:
+ - `--with-versioning` enables the [bucket versioning](https://min.io/docs/minio/linux/administration/object-management/object-versioning.html) (your app may need it)
+ - `--region=YOUR_REGION` defines a region where to create your bucket
+
+
+### Third step: Setup your app configuration to use the bucket
+
+When you setup your app's configuration, pass the following:
+ - for the endpoint url: `https://__MINIO_DOMAIN__`
+   - or alternatively `http://localhost:__MINIO_PORT__` where `__MINIO_PORT__` is retrieved using `ynh_app_setting_get --app="minio" --key="port"`;
+ - for the bucket: `__MINIO_BUCKET__`;
+ - for either the access key or the user: `__MINIO_ACCESS_KEY__`;
+ - for either the secret key or the password: `__MINIO_SECRET_KEY__`;
+
+### Limitations
+
+#### Regarding the endpoint URL
+
+That's a tricky part:
+ - When using the `__MINIO_DOMAIN__`, the user can't change the URL of their MinIO server. Or they should regenerate your app's configuration (for example by forcing an upgrade).
+ - When using the `__MINIO_PORT__`, the app should not check the certificate nor should it request fetch assets stored in the MinIO server directly from the client.
+
+#### Backuping / restoring the app
+
+You may backup and restore the app, keep in mind that the backup is not
+self-sufficient. The user should restore first the MinIO app and then the app itself.
+
+As an app packager, you should raise an error if MinIO is missing during the restoration.

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -30,12 +30,11 @@ Below we assume we simply create a bucket and a user with the name of the app.
 ynh_script_progression --message="Setting up MinIO bucket..." --weight=1
 
 sudo -u minio "$minio_install_dir/setup_app_bucket.sh" --app="$app" --secret="$minio_secret_key" \
-  --with-versioning --region=YOUR_REGION # --with-versioning and --region are optional
+  --with-versioning # --with-versioning is optional
 ```
 
 Where:
  - `--with-versioning` enables the [bucket versioning](https://min.io/docs/minio/linux/administration/object-management/object-versioning.html) (your app may need it)
- - `--region=YOUR_REGION` defines a region where to create your bucket
 
 
 ### Third step: Setup your app configuration to use the bucket

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,30 +1,61 @@
-## Comment créer une application YunoHost à l'aide de MinIO
+## Comment créer une application YunoHost avec MinIO
 
-Au cours du processus d'installation, MinIO installera à la fois le serveur MinIO et le client MinIO.
-Si votre application a besoin d'utiliser un stockage Amazon S3, je vous recommande d'utiliser le client MinIO pour créer et configurer les buckets en fonction des besoins de votre application. Vous pouvez consulter l'application outline_ynh à titre de référence.
+Pendant le processus d'installation, MinIO installe à la fois le serveur MinIO et le client MinIO.
+Si votre application nécessite l'utilisation d'un espace de stockage (*bucket*) Amazon S3, vous êtes invité à utiliser le client MinIO pour créer et configurer un bucket selon les besoins de votre application.
 
-### Première étape : récupérer les informations d'identification MinIO
+### Première étape : Définir les accès à MinIO
 
-```
+```bash
 #=================================================
 # SETUP MINIO CREDENTIALS
 #=================================================
 minio_domain=$(ynh_app_setting_get --app="minio" --key=domain)
-minio_admin=$(ynh_app_setting_get --app="minio" --key=admin)
-minio_password=$(ynh_app_setting_get --app="minio" --key=password)
-mc_path=$(ynh_app_setting_get --app="minio" --key=mc_path)
+minio_secret_key=$(ynh_string_random -l 32)
+minio_install_dir=$(ynh_app_setting_get --app="minio" --key=install_dir)
+minio_access_key=$app
+minio_bucket=$app
+
+ynh_app_setting_set --key=minio_access_key --value=$minio_access_key
+ynh_app_setting_set --key=minio_bucket --value=$minio_bucket
+ynh_app_setting_set --key=minio_secret_key --value=$minio_secret_key
 ```
 
 ### Deuxième étape : créer et configurer votre bucket
 
-```
+En supposant simplement que nous créons un bucket et un utilisateur portant le nom de l'app.
+```bash
 #=================================================
 # SETUP MINIO BUCKET
 #=================================================
-ynh_script_progression --message="Configuration du seau MinIO pour YOURAPP... » --weight=1
+ynh_script_progression --message="Setting up MinIO bucket..." --weight=1
 
-pushd "$mc_path »
-	ynh_exec_warn_less sudo -u minio ./mc mb minio/NAME_OF_YOUR_BUCKET --region "NAME_OF_YOUR_REGION"
-	ynh_exec_warn_less sudo -u minio ./mc policy set NEEDED_POLICY minio/NAME_OF_YOUR_BUCKET
-popd
+sudo -u minio "$minio_install_dir/setup_app_bucket.sh" --app="$app" --secret="$minio_secret_key" \
+  --with-versioning --region=YOUR_REGION # --with-versioning and --region étant optionnels
 ```
+
+Où:
+ - `--with-versioning` active le [versionnage du bucket](https://min.io/docs/minio/linux/administration/object-management/object-versioning.html) (votre application pourrait en avoir besoin)
+ - `--region=YOUR_REGION` définit une région où le bucket doit être créé
+
+### Troisième étape : Configurer votre application pour utiliser le bucket
+
+Lorsque vous définissez la configuration de votre application, passez les éléments suivants :
+ - pour l'URL du point d'accès (*endpoint* en anglais) : `https://__MINIO_DOMAIN__`
+   - ou sinon `http://localhost:__MINIO_PORT__` où `__MINIO_PORT__` est récupéré en utilisant `ynh_app_setting_get --app="minio" --key="port"` ;
+ - pour le nom du bucket : `__MINIO_BUCKET__`;
+ - pour l'identifiant d'accès (*access key*) ou l'utilisateur : `__MINIO_ACCESS_KEY__`;
+ - pour le mot de passe ou la clé secrète (*secret key*) : `__MINIO_SECRET_KEY__`;
+
+### Limites
+
+#### En ce qui concerne l'URL du point d'accès
+
+C'est une partie délicate :
+ - Lorsque vous utilisez `__MINIO_DOMAIN__`, l'utilisateur/rice ne peut pas modifier l'URL de son serveur Minio. Ou il/elle doit régénérer la configuration de son application (par exemple en forçant une mise à jour).
+ - Lorsque vous utilisez `__MINIO_PORT__`, l'application ne doit pas vérifier le certificat ni demander à télécharger les assets stockés dans le serveur Minio directement depuis le client.
+
+#### Sauvegarde / restauration de l'application
+
+Vous pouvez sauvegarder et restaurer l'application, gardez à l'esprit que la sauvegarde n'est pas auto-suffisante. L'utilisateur/rice doit d'abord restaurer l'application Minio et ensuite l'application elle-même.
+
+En tant que packageur d'applications, vous devriez faire en sorte que MinIO soit présent pendant la restauration.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -22,7 +22,7 @@ ynh_app_setting_set --key=minio_secret_key --value=$minio_secret_key
 
 ### Deuxième étape : créer et configurer votre bucket
 
-En supposant simplement que nous créons un bucket et un utilisateur portant le nom de l'app.
+En supposant simplement que nous créons un bucket et une clé d'accès portant le nom de l'app.
 ```bash
 #=================================================
 # SETUP MINIO BUCKET

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -30,12 +30,11 @@ En supposant simplement que nous créons un bucket et un utilisateur portant le 
 ynh_script_progression --message="Setting up MinIO bucket..." --weight=1
 
 sudo -u minio "$minio_install_dir/setup_app_bucket.sh" --app="$app" --secret="$minio_secret_key" \
-  --with-versioning --region=YOUR_REGION # --with-versioning and --region étant optionnels
+  --with-versioning # --with-versioning étant optionnel
 ```
 
 Où:
  - `--with-versioning` active le [versionnage du bucket](https://min.io/docs/minio/linux/administration/object-management/object-versioning.html) (votre application pourrait en avoir besoin)
- - `--region=YOUR_REGION` définit une région où le bucket doit être créé
 
 ### Troisième étape : Configurer votre application pour utiliser le bucket
 

--- a/scripts/install
+++ b/scripts/install
@@ -16,6 +16,13 @@ chmod +x "$install_dir/minio"
 chmod +x "$install_dir/mc"
 
 #=================================================
+# SPECIFIC SETUP
+#=================================================
+
+ynh_config_add --template="../sources/setup_app_bucket.sh" --destination="$install_dir/setup_app_bucket.sh"
+chmod 550 "$install_dir/setup_app_bucket.sh"
+
+#=================================================
 # SYSTEM CONFIGURATION
 #=================================================
 ynh_script_progression "Adding system configurations related to $app..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -71,6 +71,13 @@ chmod +x "$install_dir/minio"
 chmod +x "$install_dir/mc"
 
 #=================================================
+# SPECIFIC SETUP
+#=================================================
+
+ynh_config_add --template="../sources/setup_app_bucket.sh" --destination="$install_dir/setup_app_bucket.sh"
+chmod 550 "$install_dir/setup_app_bucket.sh"
+
+#=================================================
 # NGINX CONFIGURATION
 #=================================================
 ynh_script_progression "Upgrading NGINX web server configuration..."

--- a/sources/setup_app_bucket.sh
+++ b/sources/setup_app_bucket.sh
@@ -40,8 +40,8 @@ if [ -z "${SECRET:-}" ]; then
   exit 1
 fi
 
-ACCESS_KEY=$APP
-BUCKET=$APP
+ACCESS_KEY=${APP//_/-}
+BUCKET=${APP//_/-}
 
 policy_file=$(mktemp --suffix=".$APP.policy.json")
 minio_install_dir=$(dirname -- "$0")

--- a/sources/setup_app_bucket.sh
+++ b/sources/setup_app_bucket.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -eEu -o pipefail
+
+if [ "$(whoami)" != "minio" ]; then
+  sudo -u minio "$0" "$@"
+  exit $?
+fi
+
+mb_opts=()
+help=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --app=*) APP="${1#*=}"; shift 1;;
+    --secret=*) SECRET="${1#*=}"; shift 1;;
+    --with-versioning) mb_opts+=("--with-versioning"); shift 1;;
+    --region=*) mb_opts+=("--region" "${1#*=}"); shift 1;;
+    --help*) help=1; shift 1;;
+
+    *) echo "unknown option: $1" >&2; exit 1;;
+  esac
+done
+
+if [ "$help" == "1" ]; then
+  echo "Usage: $0 --app=\$app --secret=YOUR_SECRET [--with-versioning] [--region=YOUR_REGION]"
+  echo ""
+  echo "Set up a MinIO bucket for apps. Meant to be used by packages."
+  echo "Also creates a user in MinIO who will be granted readwrite access only to this bucket."
+  echo "See the admin documentation for more info: https://github.com/YunoHost-Apps/minio_ynh/blob/master/doc/ADMIN.md"
+  exit 0
+fi
+
+if [ -z "${APP:-}" ]; then
+  echo "Please pass the following mandatory argument: --app=\$app" >&2
+  exit 1
+fi
+
+if [ -z "${SECRET:-}" ]; then
+  echo 'Please pass the following mandatory argument: --secret="YOUR_SECRET"' >&2
+  exit 1
+fi
+
+USER=$APP
+BUCKET=$APP
+
+policy_file=$(mktemp --suffix=".$APP.policy.json")
+minio_install_dir=$(dirname -- "$0")
+
+cleanup() {
+  rv=$?
+  rm -f "$policy_file"
+  exit $rv
+}
+
+trap "cleanup" EXIT
+
+if "$minio_install_dir/mc" ls --json minio | jq -r ".key" | grep -q "^$APP/$"; then
+  echo "Bucket already exist, skip"
+  exit 0
+fi
+
+# Create a user in S3 for the app
+"$minio_install_dir/mc" admin user add minio "$USER" "$SECRET"
+
+# Create a bucket in S3 for the app
+"$minio_install_dir/mc" mb "${mb_opts[@]}" "minio/$BUCKET"
+
+# Create a new policy to give only access to the app's bucket
+# The policy_file is temporary and will be cleaned up at the end of the execution
+# NB: the `mc admin policy create` command does not seem to accept the here-documents syntax, hence the temporary file
+cat <<EOF > "$policy_file"
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [ "s3:*" ],
+    "Resource": [
+      "arn:aws:s3:::$BUCKET/*",
+      "arn:aws:s3:::$BUCKET"
+    ]
+  }]
+}
+EOF
+"$minio_install_dir/mc" admin policy create minio "readwrite-$APP" "$policy_file"
+
+# Attach the policy to the app's user on minio
+"$minio_install_dir/mc" admin policy attach minio "readwrite-$APP" --user "$USER"

--- a/sources/setup_app_bucket.sh
+++ b/sources/setup_app_bucket.sh
@@ -15,7 +15,6 @@ while [ "$#" -gt 0 ]; do
     --app=*) APP="${1#*=}"; shift 1;;
     --secret=*) SECRET="${1#*=}"; shift 1;;
     --with-versioning) mb_opts+=("--with-versioning"); shift 1;;
-    --region=*) mb_opts+=("--region" "${1#*=}"); shift 1;;
     --help*) help=1; shift 1;;
 
     *) echo "unknown option: $1" >&2; exit 1;;
@@ -23,7 +22,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "$help" == "1" ]; then
-  echo "Usage: $0 --app=\$app --secret=YOUR_SECRET [--with-versioning] [--region=YOUR_REGION]"
+  echo "Usage: $0 --app=\$app --secret=YOUR_SECRET [--with-versioning]"
   echo ""
   echo "Set up a MinIO bucket for apps. Meant to be used by packages."
   echo "Also creates a user in MinIO who will be granted readwrite access only to this bucket."


### PR DESCRIPTION
## Problem

- The documentation is outdated and does not suggest how to give the least privilege to the app

## Solution

- Update the documentation
- Add a script that creates the bucket, and the access key with the policy to give read/write access only to the bucket for the app

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
